### PR TITLE
Add Checkout Prompt blocklist and allowlist for files and directories.

### DIFF
--- a/P4EditVS/Commands.cs
+++ b/P4EditVS/Commands.cs
@@ -539,7 +539,7 @@ namespace P4EditVS
             ThreadHelper.ThrowIfNotOnUIThread();
             if (_package.AutoCheckout)
             {
-                if (_package.AutoCheckoutPrompt)
+                if (_package.AutoCheckoutPrompt || (_package.IsOnBlocklist(filePath) && !_package.IsOnAllowlist(filePath)))
                 {
                     IVsUIShell uiShell = ServiceProvider.GetService(typeof(SVsUIShell)) as IVsUIShell;
 

--- a/P4EditVS/Misc.cs
+++ b/P4EditVS/Misc.cs
@@ -84,6 +84,77 @@ namespace P4EditVS
             }
         }
 
+        // IsSubPathOf(), WithEnding() and Right() come from https://stackoverflow.com/questions/5617320/given-full-path-check-if-path-is-subdirectory-of-some-other-path-or-otherwise/31941159#31941159
+        // courtesy of @angularsen
+
+        /// <summary>
+        /// Returns true if <paramref name="path"/> starts with the path <paramref name="baseDirPath"/>.
+        /// The comparison is case-insensitive, handles / and \ slashes as folder separators and
+        /// only matches if the base dir folder name is matched exactly ("c:\foobar\file.txt" is not a sub path of "c:\foo").
+        /// </summary>
+        public static bool IsSubPathOf(this string path, string baseDirPath)
+        {
+            // We do these beforehand, so skip duplicating it
+            //string normalizedPath = Path.GetFullPath(path.Replace('/', '\\')
+            //    .WithEnding("\\"));
+            //string normalizedBaseDirPath = Path.GetFullPath(baseDirPath.Replace('/', '\\')
+            //    .WithEnding("\\"));
+            return path.StartsWith(baseDirPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string NormalizeFilePath(this string path)
+        {
+            return Path.GetFullPath(path.Trim().Replace('/', '\\').ToLower());
+        }
+
+        public static string NormalizeDirectoryPath(this string path)
+        {
+            return Path.GetFullPath(path.Trim().Replace('/', '\\').ToLower().WithEnding("\\"));
+        }
+
+        /// <summary>
+        /// Returns <paramref name="str"/> with the minimal concatenation of <paramref name="ending"/> (starting from end) that
+        /// results in satisfying .EndsWith(ending).
+        /// </summary>
+        /// <example>"hel".WithEnding("llo") returns "hello", which is the result of "hel" + "lo".</example>
+        public static string WithEnding(this string str, string ending)
+        {
+            if (str == null)
+                return ending;
+
+            string result = str;
+
+            // Right() is 1-indexed, so include these cases
+            // * Append no characters
+            // * Append up to N characters, where N is ending length
+            for (int i = 0; i <= ending.Length; i++)
+            {
+                string tmp = result + ending.Right(i);
+                if (tmp.EndsWith(ending))
+                    return tmp;
+            }
+
+            return result;
+        }
+
+        /// <summary>Gets the rightmost <paramref name="length" /> characters from a string.</summary>
+        /// <param name="value">The string to retrieve the substring from.</param>
+        /// <param name="length">The number of characters to retrieve.</param>
+        /// <returns>The substring.</returns>
+        public static string Right(this string value, int length)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException("value");
+            }
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException("length", length, "Length is less than zero");
+            }
+
+            return (length < value.Length) ? value.Substring(value.Length - length) : value;
+        }
+
         //########################################################################
         //########################################################################
 

--- a/P4EditVS/P4EditVS.cs
+++ b/P4EditVS/P4EditVS.cs
@@ -230,6 +230,10 @@ namespace P4EditVS
             {
                 return true;
             }
+            if(_checkoutPromptAllowlistDirectories.Count < 1)
+            {
+                return false;
+            }
             string filePathDirectory = filePath.Substring(0, filePath.LastIndexOf('\\') + 1);
             // Maybe we'll get lucky and it's directly in the directory we care about
             if (_checkoutPromptAllowlistDirectories.Contains(filePathDirectory))
@@ -284,6 +288,10 @@ namespace P4EditVS
             if(_checkoutPromptBlocklistFilePaths.Contains(filePath))
             {
                 return true;
+            }
+            if (_checkoutPromptBlocklistDirectories.Count < 1)
+            {
+                return false;
             }
             string filePathDirectory = filePath.Substring(0, filePath.LastIndexOf('\\') + 1);
             // Maybe we'll get lucky and it's directly in the directory we care about

--- a/P4EditVS/P4EditVS.cs
+++ b/P4EditVS/P4EditVS.cs
@@ -186,7 +186,6 @@ namespace P4EditVS
 
         private bool _hasAnyAllowlists = false;
         private HashSet<string> _checkoutPromptAllowlistDirectories;
-        private List<string> _checkoutPromptAllowlistDirectoriesList;
         private HashSet<string> _checkoutPromptAllowlistFilePaths;
         private void EnsureAllowlistsArePopulated()
         {
@@ -194,7 +193,6 @@ namespace P4EditVS
             {
                 _checkoutPromptAllowlistDirectories = new HashSet<string>();
                 _checkoutPromptAllowlistFilePaths = new HashSet<string>();
-                _checkoutPromptAllowlistDirectoriesList = new List<string>();
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
                 if(string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
                 {
@@ -206,9 +204,7 @@ namespace P4EditVS
                     var attr = File.GetAttributes(path);
                     if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
                     {
-                        string dirPath = path.NormalizeDirectoryPath();
-                        _checkoutPromptAllowlistDirectories.Add(dirPath);
-                        _checkoutPromptAllowlistDirectoriesList.Add(dirPath);
+                        _checkoutPromptAllowlistDirectories.Add(path.NormalizeDirectoryPath());
                     }
                     else
                     {
@@ -240,12 +236,11 @@ namespace P4EditVS
             {
                 return true;
             }
-            return IsInPathList(_checkoutPromptAllowlistDirectoriesList, filePathDirectory);
+            return IsInPathList(_checkoutPromptAllowlistDirectories, filePathDirectory);
         }
 
         private bool _hasAnyBlocklists = false;
         private HashSet<string> _checkoutPromptBlocklistDirectories;
-        private List<string> _checkoutPromptBlocklistDirectoriesList;
         private HashSet<string> _checkoutPromptBlocklistFilePaths;
         private void EnsureBlocklistsArePopulated()
         {
@@ -253,7 +248,6 @@ namespace P4EditVS
             {
                 _checkoutPromptBlocklistDirectories = new HashSet<string>();
                 _checkoutPromptBlocklistFilePaths = new HashSet<string>();
-                _checkoutPromptBlocklistDirectoriesList = new List<string>();
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
                 if (string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
                 {
@@ -265,9 +259,7 @@ namespace P4EditVS
                     var attr = File.GetAttributes(path);
                     if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
                     {
-                        string dirPath = path.NormalizeDirectoryPath();
-                        _checkoutPromptBlocklistDirectories.Add(dirPath);
-                        _checkoutPromptBlocklistDirectoriesList.Add(dirPath);
+                        _checkoutPromptBlocklistDirectories.Add(path.NormalizeDirectoryPath());
                     }
                     else
                     {
@@ -299,10 +291,10 @@ namespace P4EditVS
             {
                 return true;
             }
-            return IsInPathList(_checkoutPromptBlocklistDirectoriesList, filePathDirectory);
+            return IsInPathList(_checkoutPromptBlocklistDirectories, filePathDirectory);
         }
 
-        private bool IsInPathList(List<string> paths, string filePathDirectory)
+        private bool IsInPathList(HashSet<string> paths, string filePathDirectory)
         {
             foreach (string path in paths)
             {

--- a/P4EditVS/P4EditVS.cs
+++ b/P4EditVS/P4EditVS.cs
@@ -218,10 +218,11 @@ namespace P4EditVS
             {
                 return false;
             }
+            filePath = filePath.ToLower();
             string filePathDirectory = filePath.Substring(0, filePath.LastIndexOf('\\'));
             foreach (string path in paths)
             {
-                var trimmedPath = path.Trim();
+                var trimmedPath = path.Trim().ToLower();
                 if (trimmedPath == filePath || IsInDirectory(trimmedPath, filePathDirectory))
                 {
                     return true;
@@ -236,7 +237,7 @@ namespace P4EditVS
             {
                 return false;
             }
-            // DirectoryInfo doesn't work with a trailing backslash, so ensure it doesn't exist
+            // DirectoryInfo name comparison doesn't work with a trailing backslash, so ensure it doesn't exist
             int lastBackslashIndex = parentPath.LastIndexOf('\\');
             if(lastBackslashIndex == parentPath.Length - 1)
             {

--- a/P4EditVS/P4EditVS.cs
+++ b/P4EditVS/P4EditVS.cs
@@ -184,6 +184,7 @@ namespace P4EditVS
             }
         }
 
+        private bool _hasAnyAllowlists = false;
         private HashSet<string> _checkoutPromptAllowlistDirectories;
         private List<string> _checkoutPromptAllowlistDirectoriesList;
         private HashSet<string> _checkoutPromptAllowlistFilePaths;
@@ -195,6 +196,11 @@ namespace P4EditVS
                 _checkoutPromptAllowlistFilePaths = new HashSet<string>();
                 _checkoutPromptAllowlistDirectoriesList = new List<string>();
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
+                if(string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
+                {
+                    return;
+                }
+                _hasAnyAllowlists = true;
                 foreach (string path in page.CheckoutPromptAllowlist.Split(','))
                 {
                     var attr = File.GetAttributes(path);
@@ -214,11 +220,15 @@ namespace P4EditVS
 
         public bool IsOnAllowlist(string filePath)
         {
+            EnsureAllowlistsArePopulated();
+            if (!_hasAnyAllowlists)
+            {
+                return false;
+            }
             if (string.IsNullOrEmpty(filePath))
             {
                 return false;
             }
-            EnsureAllowlistsArePopulated();
             filePath = filePath.NormalizeFilePath();
             if (_checkoutPromptAllowlistFilePaths.Contains(filePath))
             {
@@ -233,6 +243,7 @@ namespace P4EditVS
             return IsInPathList(_checkoutPromptAllowlistDirectoriesList, filePathDirectory);
         }
 
+        private bool _hasAnyBlocklists = false;
         private HashSet<string> _checkoutPromptBlocklistDirectories;
         private List<string> _checkoutPromptBlocklistDirectoriesList;
         private HashSet<string> _checkoutPromptBlocklistFilePaths;
@@ -244,7 +255,12 @@ namespace P4EditVS
                 _checkoutPromptBlocklistFilePaths = new HashSet<string>();
                 _checkoutPromptBlocklistDirectoriesList = new List<string>();
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
-                foreach(string path in page.CheckoutPromptBlocklist.Split(','))
+                if (string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
+                {
+                    return;
+                }
+                _hasAnyBlocklists = true;
+                foreach (string path in page.CheckoutPromptBlocklist.Split(','))
                 {
                     var attr = File.GetAttributes(path);
                     if ((attr & FileAttributes.Directory) == FileAttributes.Directory)
@@ -263,11 +279,15 @@ namespace P4EditVS
 
         public bool IsOnBlocklist(string filePath)
         {
+            EnsureBlocklistsArePopulated();
+            if (!_hasAnyBlocklists)
+            {
+                return false;
+            }
             if (string.IsNullOrEmpty(filePath))
             {
                 return false;
             }
-            EnsureBlocklistsArePopulated();
             filePath = filePath.NormalizeFilePath();
             if(_checkoutPromptBlocklistFilePaths.Contains(filePath))
             {


### PR DESCRIPTION
This feature is to allow users to opt-in to prompts on certain files and directories. In especially large projects with lots of header dependencies, you might want to warn yourself before accidentally editing and saving a file that will cause the compilation of hundreds or thousands of other files. These two lists are an attempt at preventing that by defining areas or files where it's not safe to tread.