### PR TITLE
Add .editorconfig. Reformat files.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,217 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels =true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements =true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/P4EditVS.sln
+++ b/P4EditVS.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1022
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32901.82
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "P4EditVS", "P4EditVS\P4EditVS.csproj", "{AD81651E-2CD4-42C7-A603-B98ACBFA46EA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9D9F12D8-599C-4D5E-A6AC-A43CB82885C8}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/P4EditVS/Commands.cs
+++ b/P4EditVS/Commands.cs
@@ -841,10 +841,10 @@ namespace P4EditVS
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if(result.Stdout != null)
+            if (result.Stdout != null)
                 DumpRunnerResult(result.JobId, "stdout", result.Stdout);
 
-            if(result.Stderr != null)
+            if (result.Stderr != null)
                 DumpRunnerResult(result.JobId, "stderr", result.Stderr);
 
             DateTime now = DateTime.Now;

--- a/P4EditVS/Misc.cs
+++ b/P4EditVS/Misc.cs
@@ -80,7 +80,7 @@ namespace P4EditVS
         {
             try
             {
-                return Path.GetFileName(path); 
+                return Path.GetFileName(path);
             }
             catch (System.Exception)
             {
@@ -357,11 +357,11 @@ namespace P4EditVS
             {
             }
             catch (DirectoryNotFoundException)
-			{
+            {
 
-			}
+            }
             catch (FileNotFoundException)
-			{
+            {
             }
 
             outCreatedDefault = false;
@@ -386,16 +386,16 @@ namespace P4EditVS
         {
             if (fileName == null) return;
 
-			try
-			{
-				DoWriteXml((XmlWriterSettings settings) => XmlWriter.Create(fileName, settings), data);
-			}
-			catch(DirectoryNotFoundException)
-			{
-				Directory.CreateDirectory(GetPathDirectoryName(fileName));
-				DoWriteXml((XmlWriterSettings settings) => XmlWriter.Create(fileName, settings), data);
-			}
-		}
+            try
+            {
+                DoWriteXml((XmlWriterSettings settings) => XmlWriter.Create(fileName, settings), data);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                Directory.CreateDirectory(GetPathDirectoryName(fileName));
+                DoWriteXml((XmlWriterSettings settings) => XmlWriter.Create(fileName, settings), data);
+            }
+        }
 
         private static void DoWriteXml<T>(Func<XmlWriterSettings, XmlWriter> createWriter, T data)
         {

--- a/P4EditVS/P4EditVS.cs
+++ b/P4EditVS/P4EditVS.cs
@@ -24,18 +24,18 @@ using System.Collections.Generic;
 
 namespace P4EditVS
 {
-	/// <summary>
-	/// Values saved to the .suo file.
-	/// </summary>
-	/// <remarks>
-	/// Since it's convenient, this stuff is serialized using the XmlSerializer.
-	/// So anything in here needs to be compatible with that.
-	///
-	/// If the suo doesn't contain a SolutionOptions, the default values here
-	/// will be used. 
-	/// </remarks>
-	[System.Obsolete("Use SolutionSettings instead")]
-	public class SolutionOptions
+    /// <summary>
+    /// Values saved to the .suo file.
+    /// </summary>
+    /// <remarks>
+    /// Since it's convenient, this stuff is serialized using the XmlSerializer.
+    /// So anything in here needs to be compatible with that.
+    ///
+    /// If the suo doesn't contain a SolutionOptions, the default values here
+    /// will be used. 
+    /// </remarks>
+    [System.Obsolete("Use SolutionSettings instead")]
+    public class SolutionOptions
     {
         // Index of workspace to use.
         public int WorkspaceIndex = -1;
@@ -189,12 +189,12 @@ namespace P4EditVS
         private HashSet<string> _checkoutPromptAllowlistFilePaths;
         private void EnsureAllowlistsArePopulated()
         {
-            if(_checkoutPromptAllowlistDirectories == null)
+            if (_checkoutPromptAllowlistDirectories == null)
             {
                 _checkoutPromptAllowlistDirectories = new HashSet<string>();
                 _checkoutPromptAllowlistFilePaths = new HashSet<string>();
                 OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
-                if(string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
+                if (string.IsNullOrEmpty(page.CheckoutPromptAllowlist))
                 {
                     return;
                 }
@@ -230,7 +230,7 @@ namespace P4EditVS
             {
                 return true;
             }
-            if(_checkoutPromptAllowlistDirectories.Count < 1)
+            if (_checkoutPromptAllowlistDirectories.Count < 1)
             {
                 return false;
             }
@@ -248,7 +248,7 @@ namespace P4EditVS
         private HashSet<string> _checkoutPromptBlocklistFilePaths;
         private void EnsureBlocklistsArePopulated()
         {
-            if(_checkoutPromptBlocklistDirectories == null)
+            if (_checkoutPromptBlocklistDirectories == null)
             {
                 _checkoutPromptBlocklistDirectories = new HashSet<string>();
                 _checkoutPromptBlocklistFilePaths = new HashSet<string>();
@@ -285,7 +285,7 @@ namespace P4EditVS
                 return false;
             }
             filePath = filePath.NormalizeFilePath();
-            if(_checkoutPromptBlocklistFilePaths.Contains(filePath))
+            if (_checkoutPromptBlocklistFilePaths.Contains(filePath))
             {
                 return true;
             }
@@ -306,7 +306,7 @@ namespace P4EditVS
         {
             foreach (string path in paths)
             {
-                if(filePathDirectory.IsSubPathOf(path))
+                if (filePathDirectory.IsSubPathOf(path))
                 {
                     return true;
                 }
@@ -539,10 +539,10 @@ namespace P4EditVS
         /// </remarks>
         /// <param name="options"></param>
         [System.Obsolete("Use SolutionSettings instead")]
-		private void SetSolutionOptions(SolutionOptions options)
-		{
-			if (options.WorkspaceIndex >= -1 && options.WorkspaceIndex <= 6) _selectedWorkspace = options.WorkspaceIndex;
-		}
+        private void SetSolutionOptions(SolutionOptions options)
+        {
+            if (options.WorkspaceIndex >= -1 && options.WorkspaceIndex <= 6) _selectedWorkspace = options.WorkspaceIndex;
+        }
 
         //
         // Summary:
@@ -578,25 +578,25 @@ namespace P4EditVS
         }
         */
 
-		//
-		// Summary:
-		//     Loads user options for a given solution.
-		//
-		// Parameters:
-		//   pPersistence:
-		//     [in] Pointer to the Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence
-		//     interface on which the VSPackage should call its Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence.LoadPackageUserOpts(Microsoft.VisualStudio.Shell.Interop.IVsPersistSolutionOpts,System.String)
-		//     method for each stream name it wants to read from the user options (.opt) file.
-		//
-		//   grfLoadOpts:
-		//     [in] User options whose value is taken from the Microsoft.VisualStudio.Shell.Interop.__VSLOADUSEROPTS
-		//     DWORD.
-		//
-		// Returns:
-		//     If the method succeeds, it returns Microsoft.VisualStudio.VSConstants.S_OK. If
-		//     it fails, it returns an error code.
-		[System.Obsolete(".suo has been removed, use SolutionSettings instead. This is only used to carry existing settings over to new SolutioSettings.")]
-		public int LoadUserOptions(IVsSolutionPersistence pPersistence, [ComAliasName("Microsoft.VisualStudio.Shell.Interop.VSLOADUSEROPTS")] uint grfLoadOpts)
+        //
+        // Summary:
+        //     Loads user options for a given solution.
+        //
+        // Parameters:
+        //   pPersistence:
+        //     [in] Pointer to the Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence
+        //     interface on which the VSPackage should call its Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence.LoadPackageUserOpts(Microsoft.VisualStudio.Shell.Interop.IVsPersistSolutionOpts,System.String)
+        //     method for each stream name it wants to read from the user options (.opt) file.
+        //
+        //   grfLoadOpts:
+        //     [in] User options whose value is taken from the Microsoft.VisualStudio.Shell.Interop.__VSLOADUSEROPTS
+        //     DWORD.
+        //
+        // Returns:
+        //     If the method succeeds, it returns Microsoft.VisualStudio.VSConstants.S_OK. If
+        //     it fails, it returns an error code.
+        [System.Obsolete(".suo has been removed, use SolutionSettings instead. This is only used to carry existing settings over to new SolutioSettings.")]
+        public int LoadUserOptions(IVsSolutionPersistence pPersistence, [ComAliasName("Microsoft.VisualStudio.Shell.Interop.VSLOADUSEROPTS")] uint grfLoadOpts)
         {
             Trace.WriteLine(String.Format("P4EditVS LoadUserOptions (grfLoadOpts={0})", grfLoadOpts));
 
@@ -616,22 +616,22 @@ namespace P4EditVS
             return VSConstants.S_OK;
         }
 
-		//
-		// Summary:
-		//     Writes user options for a given solution.
-		//
-		// Parameters:
-		//   pOptionsStream:
-		//     [in] Pointer to the IStream interface to which the VSPackage should write the
-		//     user-specific options.
-		//
-		//   pszKey:
-		//     [in] Name of the stream, as provided by the VSPackage by means of the method
-		//     Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence.SavePackageUserOpts(Microsoft.VisualStudio.Shell.Interop.IVsPersistSolutionOpts,System.String).
-		//
-		// Returns:
-		//     If the method succeeds, it returns Microsoft.VisualStudio.VSConstants.S_OK. If
-		//     it fails, it returns an error code.
+        //
+        // Summary:
+        //     Writes user options for a given solution.
+        //
+        // Parameters:
+        //   pOptionsStream:
+        //     [in] Pointer to the IStream interface to which the VSPackage should write the
+        //     user-specific options.
+        //
+        //   pszKey:
+        //     [in] Name of the stream, as provided by the VSPackage by means of the method
+        //     Microsoft.VisualStudio.Shell.Interop.IVsSolutionPersistence.SavePackageUserOpts(Microsoft.VisualStudio.Shell.Interop.IVsPersistSolutionOpts,System.String).
+        //
+        // Returns:
+        //     If the method succeeds, it returns Microsoft.VisualStudio.VSConstants.S_OK. If
+        //     it fails, it returns an error code.
         /* NO LONGER USED, LEFT IN FOR REFERENCE
 		public int WriteUserOptions(IStream pOptionsStream, [ComAliasName("Microsoft.VisualStudio.OLE.Interop.LPCOLESTR")] string pszKey)
         {
@@ -670,7 +670,7 @@ namespace P4EditVS
         //     If the method succeeds, it returns Microsoft.VisualStudio.VSConstants.S_OK. If
         //     it fails, it returns an error code.
         [System.Obsolete(".suo has been removed, use SolutionSettings instead. This is only used to carry existing settings over to new SolutioSettings.")]
-		public int ReadUserOptions(IStream pOptionsStream, [ComAliasName("Microsoft.VisualStudio.OLE.Interop.LPCOLESTR")] string pszKey)
+        public int ReadUserOptions(IStream pOptionsStream, [ComAliasName("Microsoft.VisualStudio.OLE.Interop.LPCOLESTR")] string pszKey)
         {
             Trace.WriteLine(String.Format("P4EditVS ReadUserOptions (key=\"{0}\")", pszKey));
 
@@ -694,7 +694,7 @@ namespace P4EditVS
             if (stream.Length > 0) options = Misc.ReadXmlOrCreateDefault<SolutionOptions>(stream, out createdDefault);
 
             // If allow environment is not in use set it to the first workspace so some workspace is selected
-            if(createdDefault)
+            if (createdDefault)
                 options.WorkspaceIndex = GetOptionsPage().AllowEnvironment ? -1 : 0;
 
             SetSolutionOptions(options);
@@ -720,16 +720,16 @@ namespace P4EditVS
             set { _allowEnvironment = value; }
         }
 
-		private bool _autoCheckout = true;
+        private bool _autoCheckout = true;
 
-		[Category("Options")]
-		[DisplayName("Auto-Checkout Enabled")]
-		[Description("Automatically checks out files on save/build. Not recommended for slow networks as this will block Visual Studio.")]
-		public bool AutoCheckout
-		{
-			get { return _autoCheckout; }
-			set { _autoCheckout = value; }
-		}
+        [Category("Options")]
+        [DisplayName("Auto-Checkout Enabled")]
+        [Description("Automatically checks out files on save/build. Not recommended for slow networks as this will block Visual Studio.")]
+        public bool AutoCheckout
+        {
+            get { return _autoCheckout; }
+            set { _autoCheckout = value; }
+        }
 
         private bool _autoCheckoutOnEdit = false;
 
@@ -744,14 +744,14 @@ namespace P4EditVS
 
         private bool _autoCheckoutPrompt = false;
 
-		[Category("Options")]
-		[DisplayName("Prompt Before Auto-Checkout")]
-		[Description("Prompts message to automatically check out files on build and save. Auto-checkout must be enabled.")]
-		public bool AutoCheckoutPrompt
-		{
-			get { return _autoCheckoutPrompt; }
-			set { _autoCheckoutPrompt = value; }
-		}
+        [Category("Options")]
+        [DisplayName("Prompt Before Auto-Checkout")]
+        [Description("Prompts message to automatically check out files on build and save. Auto-checkout must be enabled.")]
+        public bool AutoCheckoutPrompt
+        {
+            get { return _autoCheckoutPrompt; }
+            set { _autoCheckoutPrompt = value; }
+        }
 
         private string _checkoutPromptBlocklist = "";
 

--- a/P4EditVS/SolutionSettings.cs
+++ b/P4EditVS/SolutionSettings.cs
@@ -9,94 +9,94 @@ namespace P4EditVS
 {
 
 
-	public class SolutionSettings
-	{
-		// Increment version and add patch code to Load() when changing Settings struct
-		private static readonly int _currentVersion = 0;
-		public class Settings
-		{
-			public int Version = _currentVersion;
-			public int SelectedWorkspace;
+    public class SolutionSettings
+    {
+        // Increment version and add patch code to Load() when changing Settings struct
+        private static readonly int _currentVersion = 0;
+        public class Settings
+        {
+            public int Version = _currentVersion;
+            public int SelectedWorkspace;
 
-			public Settings Copy()
-			{
-				return (Settings)this.MemberwiseClone();
-			}
-		}
+            public Settings Copy()
+            {
+                return (Settings)this.MemberwiseClone();
+            }
+        }
 
-		Settings _settings;
-		public int SelectedWorkspace { get => _settings.SelectedWorkspace; set => _settings.SelectedWorkspace = value; }
+        Settings _settings;
+        public int SelectedWorkspace { get => _settings.SelectedWorkspace; set => _settings.SelectedWorkspace = value; }
 
-		readonly string _path;
-		readonly string _fileName;
-		readonly string _pathAndFileName;
-		Task _saveTask;
+        readonly string _path;
+        readonly string _fileName;
+        readonly string _pathAndFileName;
+        Task _saveTask;
 
-		public string PathAndFileName { get => _pathAndFileName;  }
+        public string PathAndFileName { get => _pathAndFileName; }
 
-		public SolutionSettings(string dataDirectory, string solutionPathAndFileName)
-		{
-			_path = dataDirectory;
+        public SolutionSettings(string dataDirectory, string solutionPathAndFileName)
+        {
+            _path = dataDirectory;
 
-			// Build filename in form <solution_name>_<hash_of_solution_path_and_file_name>.xml
-			string solutionName = Misc.GetPathFileNameWithoutExtension(solutionPathAndFileName);
-			string hash = GetHash(solutionPathAndFileName.ToCharArray()).ToString("X"); // Use hex value to avoid MAX_PATH issues
-			_fileName = solutionName + "_" + hash + ".xml";
-			_pathAndFileName = _path + _fileName;
+            // Build filename in form <solution_name>_<hash_of_solution_path_and_file_name>.xml
+            string solutionName = Misc.GetPathFileNameWithoutExtension(solutionPathAndFileName);
+            string hash = GetHash(solutionPathAndFileName.ToCharArray()).ToString("X"); // Use hex value to avoid MAX_PATH issues
+            _fileName = solutionName + "_" + hash + ".xml";
+            _pathAndFileName = _path + _fileName;
 
         }
 
 
-		public bool DoesExist()
-		{
-			return File.Exists(PathAndFileName);
-		}
+        public bool DoesExist()
+        {
+            return File.Exists(PathAndFileName);
+        }
 
-		public void Create()
-		{
-			_settings = Misc.LoadXmlOrCreateDefault<Settings>(PathAndFileName);
-		}
+        public void Create()
+        {
+            _settings = Misc.LoadXmlOrCreateDefault<Settings>(PathAndFileName);
+        }
 
-		public void Load()
-		{
-			_settings = Misc.LoadXmlOrCreateDefault<Settings>(PathAndFileName);
-			if(_settings.Version != _currentVersion)
-			{
-				// Add patch code here
-			}
-		}
+        public void Load()
+        {
+            _settings = Misc.LoadXmlOrCreateDefault<Settings>(PathAndFileName);
+            if (_settings.Version != _currentVersion)
+            {
+                // Add patch code here
+            }
+        }
 
-		public void Save()
-		{
-			WaitForSaveTask();
-			Save(PathAndFileName, _settings);
-		}
+        public void Save()
+        {
+            WaitForSaveTask();
+            Save(PathAndFileName, _settings);
+        }
 
-		public void SaveNonBlocking()
-		{
-			Settings settings = _settings.Copy();
-			string pathAndFileName = String.Copy(PathAndFileName);
+        public void SaveNonBlocking()
+        {
+            Settings settings = _settings.Copy();
+            string pathAndFileName = String.Copy(PathAndFileName);
 
-			WaitForSaveTask();
+            WaitForSaveTask();
 
-			_saveTask = Task.Run(() =>
-			{
-				Save(pathAndFileName, settings);
-			});
-		}
+            _saveTask = Task.Run(() =>
+            {
+                Save(pathAndFileName, settings);
+            });
+        }
 
-		private void Save(string pathAndFileName, Settings settings)
-		{
-			Misc.SaveXml<Settings>(pathAndFileName, settings);
-		}
+        private void Save(string pathAndFileName, Settings settings)
+        {
+            Misc.SaveXml<Settings>(pathAndFileName, settings);
+        }
 
-		private void WaitForSaveTask()
-		{
-			if (_saveTask != null)
-			{
-				while (!_saveTask.IsCompleted) { }
-			}
-		}
+        private void WaitForSaveTask()
+        {
+            if (_saveTask != null)
+            {
+                while (!_saveTask.IsCompleted) { }
+            }
+        }
 
         private uint GetHash(char[] data)
         {
@@ -111,5 +111,5 @@ namespace P4EditVS
 
             return hash;
         }
-	}
+    }
 }


### PR DESCRIPTION
Hardly mandatory, but I have C# case statements set to format unindented, and so I keep making a mess when I'm editing the P4EditVS code.

Then I found out you can have project-specific C# editor config files! So here's one. This does introduce a few whitespace changes, but not loads.